### PR TITLE
1.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plyvel" %}
-{% set version = "1.4.0" %}
+{% set version = "1.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 4ea98bea04ebf0f44747bacdfafefc8827787106fbb787f0aedc46482b2dfd53
+  sha256: cd918e0b31690abcd3d202a8742caf951ab2fe1573de7af71c38456847f9202b
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - leveldb 1.23
   run:
     - python
-    - leveldb >=1.20,<1.21.0a0
+    - leveldb
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
     - python
-    - leveldb
+    - leveldb 1.23
   run:
     - python
     - leveldb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - leveldb 1.23
   run:
     - python
-    - leveldb
+    - leveldb >=1.23,<1.24.0a0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,6 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  # trigger: 0
-  ignore_run_exports:  # [win]
-    - leveldb          # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - leveldb 1.23
   run:
     - python
-    - leveldb
+    - leveldb >=1.20,<1.21.0a0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,12 @@ requirements:
     - leveldb
 
 test:
+  requires:
+    - pip
   imports:
     - plyvel
+  commands:
+    - pip check
 
 about:
   home: https://pypi.org/project/plyvel/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,10 +35,16 @@ test:
     - pip check
 
 about:
-  home: https://pypi.org/project/plyvel/
+  home: https://github.com/wbolster/plyvel
+  dev_url: https://github.com/wbolster/plyvel
+  doc_url: https://plyvel.readthedocs.io/
   summary: Plyvel, a fast and feature-rich Python interface to LevelDB
+  description: |
+    Plyvel is a fast and feature-rich Python interface to LevelDB.
+    Plyvel has a rich feature set, high performance, and a friendly Pythonic API.
   license: BSD-3-Clause
   license_file: LICENSE.rst
+  license_family: BSD
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<37]
+  skip: True  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:


### PR DESCRIPTION
# plyvel v1.5.0

upstream: https://github.com/wbolster/plyvel/tree/1.5.0
release notes: https://plyvel.readthedocs.io/en/latest/news.html#plyvel-1-5-0
license: https://github.com/wbolster/plyvel/blob/1.5.0/LICENSE.rst

## Changes
- Bump version and SHA
- Remove ignore_run_exports
- Add pip check
- Update about section

## Notes
- This release adds support for python 3.11